### PR TITLE
Pass messages as mutable references

### DIFF
--- a/examples/nrf52/microbit-uart/src/server.rs
+++ b/examples/nrf52/microbit-uart/src/server.rs
@@ -37,7 +37,7 @@ impl<U: Write + Read + 'static> Actor for EchoServer<U> {
 
     fn on_message<'m>(
         self: Pin<&'m mut Self>,
-        _: &'m Self::Message<'m>,
+        _: &'m mut Self::Message<'m>,
     ) -> Self::OnMessageFuture<'m> {
         async move {}
     }

--- a/examples/std/hello/src/main.rs
+++ b/examples/std/hello/src/main.rs
@@ -33,7 +33,7 @@ impl Actor for MyActor {
 
     fn on_message<'m>(
         mut self: Pin<&'m mut Self>,
-        message: &'m Self::Message<'m>,
+        message: &'m mut Self::Message<'m>,
     ) -> Self::OnMessageFuture<'m> {
         async move {
             log::info!("[{}] hello {}: {}", self.name, message.0, self.counter);
@@ -76,7 +76,7 @@ async fn main(context: DeviceContext<MyDevice>) {
     let b_addr = context.device().b.address();
     loop {
         Timer::after(Duration::from_secs(1)).await;
-        a_addr.send(&SayHello("World")).await;
-        b_addr.send(&SayHello("You")).await;
+        a_addr.send(&mut SayHello("World")).await;
+        b_addr.send(&mut SayHello("You")).await;
     }
 }


### PR DESCRIPTION
* Work around lifetimes by transmuting message lifetimes to match that
  of the receiver. This _should_ be valid, because we know that sender
  will await the message receiver to finish before it drops the message
  (otherwise it will panic!)