### PR TITLE
Make actor queue size configurable as associated type

### DIFF
--- a/actors/src/button.rs
+++ b/actors/src/button.rs
@@ -3,6 +3,7 @@ use core::marker::PhantomData;
 use core::pin::Pin;
 use drogue_device_kernel::{
     actor::{Actor, Address},
+    channel::consts,
     util::ImmediateFuture,
 };
 use embassy_traits::gpio::WaitForAnyEdge;
@@ -66,6 +67,7 @@ impl<
         A: Actor<Message<'a> = M> + 'a,
     > Actor for Button<'a, P, M, A>
 {
+    type QueueLength<'m> where 'a: 'm = consts::U0;
     type Configuration = Address<'a, A>;
     type Message<'m> where 'a: 'm = ();
     type OnStartFuture<'m> where 'a: 'm = impl Future<Output = ()> + 'm;

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(min_type_alias_impl_trait)]
 #![feature(impl_trait_in_bindings)]
 #![feature(generic_associated_types)]
+#![feature(associated_type_defaults)]
 #![feature(type_alias_impl_trait)]
 
 pub(crate) mod fmt;


### PR DESCRIPTION
Making it an associated type avoids needing to pass queue size as a
parameter to ActorState and Address, which makes code very
template-fatigued.

Downside is that min const generics doesn't support assoc types, so we
wont be able to use const generic heapless.