### PR TITLE
Add timer implementation

### DIFF
--- a/actors/Cargo.toml
+++ b/actors/Cargo.toml
@@ -22,6 +22,12 @@ optional = true
 version = "0.2"
 optional = true
 
+[dependencies.embassy]
+git = "https://github.com/drogue-iot/embassy.git"
+branch = "drogue"
+#path = "../../../embassy/embassy-traits"
+default-features = false
+
 [dependencies.embassy-traits]
 git = "https://github.com/drogue-iot/embassy.git"
 branch = "drogue"
@@ -33,6 +39,7 @@ git = "https://github.com/drogue-iot/embassy.git"
 branch = "drogue"
 #path = "../../../embassy/embassy"
 default-features = false
+features = ["std"]
 
 [dev-dependencies.drogue-device]
 path = "../device"

--- a/actors/src/lib.rs
+++ b/actors/src/lib.rs
@@ -9,3 +9,4 @@
 pub(crate) mod fmt;
 
 pub mod button;
+pub mod timer;

--- a/actors/src/timer.rs
+++ b/actors/src/timer.rs
@@ -1,0 +1,129 @@
+use core::future::Future;
+use core::pin::Pin;
+use drogue_device_kernel::{
+    actor::{Actor, Address},
+    util::ImmediateFuture,
+};
+use embassy::time;
+
+pub struct Timer<'a, A: Actor + 'a> {
+    _marker: core::marker::PhantomData<&'a A>,
+}
+
+pub enum TimerMessage<'m, A: Actor + 'm> {
+    Delay(time::Duration),
+    Schedule(time::Duration, Address<'m, A>, Option<A::Message<'m>>),
+}
+
+impl<'m, A: Actor + 'm> TimerMessage<'m, A> {
+    pub fn delay(duration: time::Duration) -> Self {
+        TimerMessage::Delay(duration)
+    }
+
+    pub fn schedule(
+        duration: time::Duration,
+        destination: Address<'m, A>,
+        message: A::Message<'m>,
+    ) -> Self {
+        TimerMessage::Schedule(duration, destination, Some(message))
+    }
+}
+
+impl<'a, A: Actor + 'a> Timer<'a, A> {
+    pub fn new() -> Self {
+        Self {
+            _marker: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<'a, A: Actor + 'a> Actor for Timer<'a, A> {
+    #[rustfmt::skip]
+    type Message<'m> where 'a: 'm = TimerMessage<'m, A>;
+    #[rustfmt::skip]
+    type OnStartFuture<'m> where 'a: 'm = ImmediateFuture;
+    #[rustfmt::skip]
+    type OnMessageFuture<'m> where 'a: 'm = impl Future<Output = ()> + 'm;
+
+    fn on_start(self: Pin<&mut Self>) -> Self::OnStartFuture<'_> {
+        ImmediateFuture::new()
+    }
+
+    fn on_message<'m>(
+        self: Pin<&'m mut Self>,
+        message: &'m mut Self::Message<'m>,
+    ) -> Self::OnMessageFuture<'m> {
+        async move {
+            match message {
+                TimerMessage::Delay(dur) => {
+                    time::Timer::after(*dur).await;
+                }
+                TimerMessage::Schedule(dur, address, message) => {
+                    time::Timer::after(*dur).await;
+                    address.notify(message.take().unwrap()).await;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+    use drogue_device::{testutil::*, *};
+
+    #[derive(Device)]
+    struct ScheduleDevice {
+        handler: ActorState<'static, TestHandler>,
+        timer: ActorState<'static, Timer<'static, TestHandler>>,
+    }
+
+    #[drogue::test]
+    async fn test_schedule(mut context: TestContext<ScheduleDevice>) {
+        let notified = context.signal();
+        context.configure(ScheduleDevice {
+            handler: ActorState::new(TestHandler::new(notified)),
+            timer: ActorState::new(Timer::new()),
+        });
+
+        let (timer_addr, handler_addr) = context.mount(|device| {
+            let handler_addr = device.handler.mount(());
+            (device.timer.mount(()), handler_addr)
+        });
+
+        let before = time::Instant::now();
+        timer_addr
+            .notify(TimerMessage::schedule(
+                time::Duration::from_secs(1),
+                handler_addr,
+                TestMessage(1),
+            ))
+            .await;
+        notified.wait_signaled().await;
+        let after = time::Instant::now();
+        assert!(after.as_secs() >= before.as_secs() + 1);
+        assert_eq!(1, notified.message().unwrap().0);
+    }
+
+    #[derive(Device)]
+    struct DelayDevice {
+        timer: ActorState<'static, Timer<'static, TestHandler>>,
+    }
+
+    #[drogue::test]
+    async fn test_delay(mut context: TestContext<DelayDevice>) {
+        context.configure(DelayDevice {
+            timer: ActorState::new(Timer::new()),
+        });
+
+        let timer = context.mount(|device| device.timer.mount(()));
+
+        let before = time::Instant::now();
+        timer
+            .send(&mut TimerMessage::Delay(time::Duration::from_secs(1)))
+            .await;
+        let after = time::Instant::now();
+        assert!(after.as_secs() >= before.as_secs() + 1);
+    }
+}

--- a/kernel/src/actor.rs
+++ b/kernel/src/actor.rs
@@ -13,7 +13,7 @@ pub trait Actor: Sized {
     type MaxQueueSize<'a>: ArrayLength<ActorMessage<'a, Self>> + ArrayLength<SignalSlot> + 'a where Self: 'a = consts::U1;
 
     /// The configuration that this actor will expect when mounted.
-    type Configuration;
+    type Configuration = ();
 
     /// The message type that this actor will handle in `on_message`.
     type Message<'a>: Sized
@@ -201,6 +201,7 @@ impl<'a, A: Actor> ActorState<'a, A> {
     }
 }
 
+#[derive(PartialEq, Eq)]
 enum SendState {
     WaitChannel,
     WaitSignal,

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::spanned::Spanned;
 use syn::{self, Data, DataStruct, Fields};
 
@@ -155,6 +155,107 @@ pub fn main(_: TokenStream, item: TokenStream) -> TokenStream {
         async fn main(spawner: ::drogue_device::reexport::embassy::executor::Spawner) {
             let context = DeviceContext::new(spawner, &DEVICE);
             spawner.spawn(__drogue_main(context)).unwrap();
+        }
+    };
+    result.into()
+}
+
+#[proc_macro_attribute]
+pub fn test(_: TokenStream, item: TokenStream) -> TokenStream {
+    let task_fn = syn::parse_macro_input!(item as syn::ItemFn);
+
+    let mut fail = false;
+    if task_fn.sig.asyncness.is_none() {
+        task_fn
+            .sig
+            .span()
+            .unwrap()
+            .error("test function must be async")
+            .emit();
+        fail = true;
+    }
+    if !task_fn.sig.generics.params.is_empty() {
+        task_fn
+            .sig
+            .span()
+            .unwrap()
+            .error("test function must not be generic")
+            .emit();
+        fail = true;
+    }
+
+    let args = task_fn.sig.inputs.clone();
+
+    if args.len() != 1 {
+        task_fn
+            .sig
+            .span()
+            .unwrap()
+            .error("test function must have one argument")
+            .emit();
+        fail = true;
+    }
+
+    let mut device_type = None;
+    if let syn::FnArg::Typed(t) = &args[0] {
+        if let syn::Type::Path(ref tp) = *t.ty {
+            if tp.path.segments[0].ident == "TestContext" {
+                if let syn::PathArguments::AngleBracketed(args) = &tp.path.segments[0].arguments {
+                    for arg in args.args.iter() {
+                        if let syn::GenericArgument::Type(syn::Type::Path(tp)) = arg {
+                            device_type = tp.path.get_ident();
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    if device_type.is_none() {
+        task_fn
+            .sig
+            .span()
+            .unwrap()
+            .error("main function test context argument must take a generic type parameter implementing Device trait")
+            .emit();
+        fail = true;
+    }
+
+    if fail {
+        return TokenStream::new();
+    }
+
+    let test_name = task_fn.sig.ident;
+    let device_type = device_type.take().unwrap();
+    let task_fn_body = task_fn.block;
+    let drogue_test_name = format_ident!("__drogue_test_{}", test_name);
+
+    let result = quote! {
+
+        #[::drogue_device::reexport::embassy::task(embassy_prefix= "::drogue_device::reexport::")]
+        async fn #drogue_test_name(#args) {
+            #task_fn_body
+        }
+
+        #[test]
+        fn #test_name() {
+        static DEVICE: ::drogue_device::reexport::embassy::util::Forever<#device_type> = ::drogue_device::reexport::embassy::util::Forever::new();
+        static RUNNER: ::drogue_device::reexport::embassy::util::Forever<TestRunner> = ::drogue_device::reexport::embassy::util::Forever::new();
+        static EXECUTOR: ::drogue_device::reexport::embassy::util::Forever<::drogue_device::reexport::embassy_std::Executor> = ::drogue_device::reexport::embassy::util::Forever::new();
+
+            let executor = EXECUTOR.put(::drogue_device::reexport::embassy_std::Executor::new());
+            let runner = RUNNER.put(TestRunner::new());
+
+            executor.initialize(|spawner| {
+                let context = DeviceContext::new(spawner, &DEVICE);
+                let runner = unsafe { RUNNER.steal() };
+                spawner.spawn(#drogue_test_name(TestContext::new(runner, context))).unwrap();
+            });
+
+            while !runner.is_done() {
+                executor.run_until_idle();
+            }
         }
     };
     result.into()


### PR DESCRIPTION
Add timer implementation that supports delay and schedule.
Add #[drogue::test] macro that simplifies writing unit tests