### PR TITLE
Add PackageConfig trait

### DIFF
--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -81,7 +81,7 @@ pub use drogue_device_kernel::{
     actor::{Actor, ActorContext, Address},
     channel::{consts, Channel},
     device::{Device, DeviceContext},
-    package::{Package, PackageContext},
+    package::{Package, PackageConfig, PackageContext},
     util::ImmediateFuture,
 };
 

--- a/examples/std/hello/src/main.rs
+++ b/examples/std/hello/src/main.rs
@@ -68,6 +68,11 @@ pub struct MyPack {
     c: ActorContext<'static, MyActor>,
 }
 
+// The PackageConfig trait must be implemented to specify the primary actor for a package.
+impl PackageConfig for MyPack {
+    type Primary = MyActor;
+}
+
 #[drogue::main]
 async fn main(mut context: DeviceContext<MyDevice>) {
     env_logger::builder()


### PR DESCRIPTION
This trait is required implemented by all packages, and allows
a package to signal a primary actor for its interface