### PR TITLE
Merge notify and request queues

### DIFF
--- a/device/src/actors/button.rs
+++ b/device/src/actors/button.rs
@@ -45,12 +45,7 @@ impl<'a, P: WaitForAnyEdge + InputPin + 'a, A: Actor + FromButtonEvent<A::Messag
     for Button<'a, P, A>
 {
     #[rustfmt::skip]
-    type MaxNotifyQueueSize<'m>
-    where
-        'a: 'm,
-    = consts::U0;
-    #[rustfmt::skip]
-    type MaxRequestQueueSize<'m>
+    type MaxMessageQueueSize<'m>
     where
         'a: 'm,
     = consts::U0;

--- a/device/src/actors/led/mod.rs
+++ b/device/src/actors/led/mod.rs
@@ -36,7 +36,7 @@ where
     P: OutputPin,
 {
     #[rustfmt::skip]
-    type MaxNotifyQueueSize<'m> where Self: 'm = consts::U16;
+    type MaxMessageQueueSize<'m> where Self: 'm = consts::U1;
     type Configuration = ();
     #[rustfmt::skip]
     type Message<'m> where Self: 'm = LedMessage;

--- a/examples/stm32l0xx/lora-discovery/src/lora.rs
+++ b/examples/stm32l0xx/lora-discovery/src/lora.rs
@@ -38,8 +38,6 @@ where
     D: LoraDriver,
 {
     #[rustfmt::skip]
-    type MaxNotifyQueueSize<'m> where Self: 'm = consts::U0;
-    #[rustfmt::skip]
     type Configuration = ();
     #[rustfmt::skip]
     type Message<'m> where D: 'm = LoraCommand<'m>;


### PR DESCRIPTION
Keeping them separate seems not worth the effort, as it became difficult
for Actor writes to choose which queue sizes to configure, without being able to control
which queue user requests ended up in.  Optimizations for reducing per-message overhead should be attempted
instead.

The findings from my experiments are summarized here:

![image](https://user-images.githubusercontent.com/19670/116616264-cb5e0300-a93c-11eb-8ab4-e902fa118499.png)

The "Actor Size" is ActorContext<MyActor> where MyActor is an empty struct. The Queue Length is the selected length of the input message queue. Old == existing drogue device. New == drogue-device-ng. After this change is merge, the numbers from the "Actor Size New" would be produced.

With the old drogue-device, the per-element cost in the queue is lower than for the per-element cost that this change reverts to. However, the "base" cost for an actor is very low. With the separate notify queue mechanism (that this change reverts), the per-element cost is only 8 bytes, but the downside is that the base cost is high.

Note that these measurements were done on a 64 bit host, which means pointers are twice the size compared to a cortex-m. This means the cross-over probably be better in favor of -ng.

@bobmcwhirter @jcrossley3 FYI