### PR TITLE
Add LED trait and tested ticker

### DIFF
--- a/device/src/drivers/led/gpio.rs
+++ b/device/src/drivers/led/gpio.rs
@@ -1,0 +1,48 @@
+use crate::traits::led::Led;
+use embedded_hal::digital::v2::OutputPin;
+
+pub struct GpioLed<P>
+where
+    P: OutputPin,
+{
+    pin: P,
+    state: bool,
+}
+
+impl<P> GpioLed<P>
+where
+    P: OutputPin,
+{
+    pub fn new(pin: P) -> Self {
+        Self { pin, state: false }
+    }
+}
+
+impl<P> Led for GpioLed<P>
+where
+    P: OutputPin,
+{
+    type Error = P::Error;
+
+    fn set(&mut self, state: bool) -> Result<(), Self::Error> {
+        match state {
+            true => self.pin.set_high(),
+            false => self.pin.set_low(),
+        }?;
+        self.state = state;
+        Ok(())
+    }
+
+    fn state(&self) -> Result<bool, Self::Error> {
+        Ok(self.state)
+    }
+}
+
+impl<P> From<P> for GpioLed<P>
+where
+    P: OutputPin,
+{
+    fn from(pin: P) -> Self {
+        Self::new(pin)
+    }
+}

--- a/device/src/drivers/led/mod.rs
+++ b/device/src/drivers/led/mod.rs
@@ -1,0 +1,1 @@
+pub mod gpio;

--- a/device/src/drivers/mod.rs
+++ b/device/src/drivers/mod.rs
@@ -1,2 +1,3 @@
+pub mod led;
 pub mod lora;
 pub mod wifi;

--- a/device/src/traits/led.rs
+++ b/device/src/traits/led.rs
@@ -1,0 +1,19 @@
+/// Trait for a simple LED.
+pub trait Led {
+    type Error;
+
+    fn set(&mut self, state: bool) -> Result<(), Self::Error>;
+    fn state(&self) -> Result<bool, Self::Error>;
+
+    fn on(&mut self) -> Result<(), Self::Error> {
+        self.set(true)
+    }
+
+    fn off(&mut self) -> Result<(), Self::Error> {
+        self.set(false)
+    }
+
+    fn toggle(&mut self) -> Result<(), Self::Error> {
+        self.set(!self.state()?)
+    }
+}

--- a/device/src/traits/mod.rs
+++ b/device/src/traits/mod.rs
@@ -1,4 +1,5 @@
 pub mod ip;
+pub mod led;
 pub mod lora;
 pub mod tcp;
 pub mod wifi;

--- a/examples/stm32l0xx/lora-discovery/Cargo.toml
+++ b/examples/stm32l0xx/lora-discovery/Cargo.toml
@@ -19,6 +19,8 @@ panic-probe = { version = "0.2.0", features = ["print-rtt"] }
 drogue-device = { path = "../../../device", features = ["log", "chip+stm32l0x2", "lora+sx127x"] }
 cortex-m-rt = "0.6"
 cortex-m = { version = "0.7", features = ["inline-asm"] }
+heapless = "0.6"
+void = { version = "1", default-features = false }
 
 # TODO: Get rid of these
 embassy = {git = "https://github.com/drogue-iot/embassy.git", branch = "drogue", default-features = false } #, path = "../../../embassy/embassy" }

--- a/examples/stm32l0xx/lora-discovery/README.adoc
+++ b/examples/stm32l0xx/lora-discovery/README.adoc
@@ -2,11 +2,6 @@
 
 This example application runs out of the box on the STM32 LoRa Discovery Kit (B-L072Z-LRWAN1).
 
-You can configure
-It provides a UART echo server that will echo characters you write to
-the micro:bit serial interface, and it will display ascii characters on
-the 5x5 LED display.
-
 === Prerequisites
 
 ==== Hardware
@@ -16,7 +11,7 @@ the 5x5 LED display.
 ==== Software
 
 To build and flash the example, you need to have
-https://rustup.rs/[Rust Nightly]. In pratice
+https://rustup.rs/[Rust Nightly]. In practice
 you can use whatever tool you want to flash the device, but this guide
 will assume that `probe-run` is used (`cargo install probe-run`).
 
@@ -61,4 +56,14 @@ cargo +nightly run --release -- --probe <VID>:<PID>
 
 === Usage
 
-Once the device is flashed, it will connect to the local LoRaWAN network. Once the network is joined, you can press the blue button on the development kit to send a test message "ping".
+Once the device is flashed, it will connect to the local LoRaWAN network. Once the network is joined, you can press
+the blue button on the development kit to send a test message `ping:<num-clicks>`, where `num-clicks` is the number
+of times you pressed the button since resetting the board.
+
+==== LEDs
+
+The board features 4 user controllable LEDs. The program will use 3 of them to show the internal status:
+
+Red:: Will light up when starting and turn off once it joined the LoRa network.
+Green:: Turns on while sending the uplink message.
+Blue:: Can be controlled through the downlink message: `led:on` or `led:off`.

--- a/examples/stm32l0xx/lora-discovery/src/app.rs
+++ b/examples/stm32l0xx/lora-discovery/src/app.rs
@@ -1,102 +1,164 @@
 use crate::lora::*;
+use core::fmt::Write;
 use core::future::Future;
 use core::pin::Pin;
-use drogue_device::actors::led::{Led, LedMessage};
-use drogue_device::{actors::button::*, traits::lora::*, *};
+use drogue_device::{
+    actors::button::*,
+    traits::{led::*, lora::*},
+    *,
+};
 use embassy_stm32::system::OutputPin;
+use heapless::String;
 
 #[derive(Clone, Copy)]
 pub enum Command {
     Tick,
     Send,
+    TickAndSend,
 }
 
-impl<D, P1, P2, P3, P4> FromButtonEvent<Command> for App<D, P1, P2, P3, P4>
+impl<D, L1, L2, L3, L4> FromButtonEvent<Command> for App<D, L1, L2, L3, L4>
 where
     D: LoraDriver,
-    P1: OutputPin + 'static,
-    P2: OutputPin + 'static,
-    P3: OutputPin + 'static,
-    P4: OutputPin + 'static,
+    L1: Led,
+    L2: Led,
+    L3: Led,
+    L4: Led,
 {
     fn from(event: ButtonEvent) -> Option<Command> {
         match event {
             ButtonEvent::Pressed => None,
-            ButtonEvent::Released => Some(Command::Tick),
+            ButtonEvent::Released => Some(Command::TickAndSend),
         }
     }
 }
 
-pub struct AppConfig<'a, D, P1, P2, P3, P4>
+pub struct AppConfig<'a, D>
 where
     D: LoraDriver + 'a,
-    P1: OutputPin + 'a,
-    P2: OutputPin + 'a,
-    P3: OutputPin + 'a,
-    P4: OutputPin + 'a,
 {
     // lora actor
     pub lora: Address<'a, LoraActor<D>>,
-    // green led
-    pub led1: Address<'a, Led<P1>>,
-    // green led 2
-    pub led2: Address<'a, Led<P2>>,
-    // blue led
-    pub led3: Address<'a, Led<P3>>,
-    // red led
-    pub led4: Address<'a, Led<P4>>,
 }
 
-pub struct App<D, P1, P2, P3, P4>
+pub struct AppInitConfig<L1, L2, L3, L4>
+where
+    L1: Led,
+    L2: Led,
+    L3: Led,
+    L4: Led,
+{
+    pub lora: Option<LoraConfig>,
+    pub init_led: L1,
+    pub tx_led: L2,
+    pub user_led: L3,
+    pub green_led: L4,
+}
+
+pub struct App<D, L1, L2, L3, L4>
 where
     D: LoraDriver + 'static,
-    P1: OutputPin + 'static,
-    P2: OutputPin + 'static,
-    P3: OutputPin + 'static,
-    P4: OutputPin + 'static,
+    L1: Led,
+    L2: Led,
+    L3: Led,
+    L4: Led,
 {
-    config: Option<LoraConfig>,
-    cfg: Option<AppConfig<'static, D, P1, P2, P3, P4>>,
+    config: AppInitConfig<L1, L2, L3, L4>,
+    cfg: Option<AppConfig<'static, D>>,
     counter: usize,
 }
 
-impl<D, P1, P2, P3, P4> App<D, P1, P2, P3, P4>
+impl<D, L1, L2, L3, L4> App<D, L1, L2, L3, L4>
 where
     D: LoraDriver,
-    P1: OutputPin + 'static,
-    P2: OutputPin + 'static,
-    P3: OutputPin + 'static,
-    P4: OutputPin + 'static,
+    L1: Led,
+    L2: Led,
+    L3: Led,
+    L4: Led,
 {
-    pub fn new(config: LoraConfig) -> Self {
+    pub fn new(config: AppInitConfig<L1, L2, L3, L4>) -> Self {
         Self {
-            config: Some(config),
+            config,
             cfg: None,
             counter: 0,
         }
     }
+
+    fn tick(&mut self) {
+        self.counter += 1;
+        log::info!("Ticked: {}", self.counter);
+    }
+
+    async fn send(&mut self) {
+        log::info!("Sending message...");
+        self.config.tx_led.on().ok();
+
+        if let Some(cfg) = &self.cfg {
+            let mut tx = String::<heapless::consts::U32>::new();
+            write!(&mut tx, "ping:{}", self.counter).ok();
+            log::info!("Message: {}", &tx);
+            let tx = tx.into_bytes();
+
+            let mut rx = [0; 64];
+            let result = cfg.lora.request(LoraCommand::SendRecv(&tx, &mut rx)).await;
+
+            match result {
+                LoraResult::OkSent(rx_len) => {
+                    log::info!("Message sent!");
+                    if rx_len > 0 {
+                        let response = &rx[0..rx_len];
+                        match core::str::from_utf8(response) {
+                            Ok(str) => {
+                                log::info!("Received {} bytes from uplink:\n{}", rx_len, str)
+                            }
+                            Err(_) => log::info!(
+                                "Received {} bytes from uplink: {:x?}",
+                                rx_len,
+                                &rx[0..rx_len]
+                            ),
+                        }
+                        match response {
+                            b"led:on" => {
+                                self.config.user_led.on().ok();
+                            }
+                            b"led:off" => {
+                                self.config.user_led.off().ok();
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                LoraResult::Err(e) => {
+                    log::error!("Error sending message: {:?}", e);
+                }
+                _ => {}
+            }
+        }
+
+        self.config.tx_led.off().ok();
+    }
 }
 
-impl<D, P1, P2, P3, P4> Unpin for App<D, P1, P2, P3, P4>
+impl<D, L1, L2, L3, L4> Unpin for App<D, L1, L2, L3, L4>
 where
     D: LoraDriver,
-    P1: OutputPin + 'static,
-    P2: OutputPin + 'static,
-    P3: OutputPin + 'static,
-    P4: OutputPin + 'static,
+    L1: Led,
+    L2: Led,
+    L3: Led,
+    L4: Led,
 {
 }
 
-impl<D, P1, P2, P3, P4> Actor for App<D, P1, P2, P3, P4>
+impl<D, L1, L2, L3, L4> Actor for App<D, L1, L2, L3, L4>
 where
     D: LoraDriver + 'static,
-    P1: OutputPin + 'static,
-    P2: OutputPin + 'static,
-    P3: OutputPin + 'static,
-    P4: OutputPin + 'static,
+    L1: Led + 'static,
+    L2: Led + 'static,
+    L3: Led + 'static,
+    L4: Led + 'static,
 {
     #[rustfmt::skip]
-    type Configuration = AppConfig<'static, D, P1, P2, P3, P4>;
+    type Configuration = AppConfig<'static, D>;
     #[rustfmt::skip]
     type Message<'m> where D: 'm = Command;
     #[rustfmt::skip]
@@ -113,13 +175,13 @@ where
     fn on_start<'m>(mut self: Pin<&'m mut Self>) -> Self::OnStartFuture<'m> {
         async move {
             log_stack!();
-            let config = self.config.take().unwrap();
-            if let Some(cfg) = &self.cfg {
-                cfg.led4.notify(LedMessage::On).await;
-                cfg.lora.request(LoraCommand::Configure(&config)).await;
+            let lora_config = self.config.lora.take().unwrap();
+            self.config.init_led.on().ok();
+            if let Some(ref cfg) = self.cfg {
+                cfg.lora.request(LoraCommand::Configure(&lora_config)).await;
                 cfg.lora.request(LoraCommand::Join).await;
-                cfg.led4.notify(LedMessage::Off).await;
             }
+            self.config.init_led.off().ok();
         }
     }
 
@@ -131,44 +193,14 @@ where
             log_stack!();
             match message {
                 Command::Tick => {
-                    self.counter += 1;
-                    log::info!("Ticked: {}", self.counter);
+                    self.tick();
                 }
                 Command::Send => {
-                    if let Some(cfg) = &self.cfg {
-                        log::info!("Sending message...");
-                        cfg.led1.notify(LedMessage::On).await;
-                        let mut rx = [0; 255];
-                        let result = cfg
-                            .lora
-                            .request(LoraCommand::SendRecv("ping".as_bytes(), &mut rx))
-                            .await;
-
-                        cfg.led1.notify(LedMessage::Off).await;
-                        match result {
-                            LoraResult::OkSent(rx_len) => {
-                                log::info!("Message sent!");
-                                let response = &rx[0..rx_len];
-                                match core::str::from_utf8(response) {
-                                    Ok(str) => log::info!("Received from uplink:\n{}", str),
-                                    Err(_) => log::info!(
-                                        "Received {} bytes from uplink: {:x?}",
-                                        rx_len,
-                                        &rx[0..rx_len]
-                                    ),
-                                }
-                                match response {
-                                    b"led:on" => cfg.led3.notify(LedMessage::On).await,
-                                    b"led:off" => cfg.led3.notify(LedMessage::Off).await,
-                                    _ => {}
-                                }
-                            }
-                            LoraResult::Err(e) => {
-                                log::error!("Error sending message: {:?}", e);
-                            }
-                            _ => {}
-                        }
-                    }
+                    self.send().await;
+                }
+                Command::TickAndSend => {
+                    self.tick();
+                    self.send().await;
                 }
             }
         }

--- a/examples/stm32l0xx/lora-discovery/src/main.rs
+++ b/examples/stm32l0xx/lora-discovery/src/main.rs
@@ -15,8 +15,8 @@ use rtt_target::rtt_init_print;
 
 use drogue_device::{
     actors::button::*,
-    actors::led::*,
     actors::ticker::*,
+    drivers::led::gpio::*,
     drivers::lora::sx127x::*,
     stm32::{
         exti::ExtiPin,
@@ -86,26 +86,14 @@ type Led2Pin = PA5<Output<PushPull>>;
 type Led3Pin = PB6<Output<PushPull>>;
 type Led4Pin = PB7<Output<PushPull>>;
 
+type MyApp =
+    App<Sx127x<'static>, GpioLed<Led4Pin>, GpioLed<Led2Pin>, GpioLed<Led3Pin>, GpioLed<Led1Pin>>;
+
 #[derive(Device)]
 pub struct MyDevice {
     lora: ActorContext<'static, LoraActor<Sx127x<'static>>>,
-    button: ActorContext<
-        'static,
-        Button<
-            'static,
-            ExtiPin<PB2<Input<PullUp>>>,
-            App<Sx127x<'static>, Led1Pin, Led2Pin, Led3Pin, Led4Pin>,
-        >,
-    >,
-    app: ActorContext<'static, App<Sx127x<'static>, Led1Pin, Led2Pin, Led3Pin, Led4Pin>>,
-    led1: ActorContext<'static, Led<Led1Pin>>,
-    led2: ActorContext<'static, Led<Led2Pin>>,
-    led3: ActorContext<'static, Led<Led3Pin>>,
-    led4: ActorContext<'static, Led<Led4Pin>>,
-    ticker: ActorContext<
-        'static,
-        Ticker<'static, App<Sx127x<'static>, Led1Pin, Led2Pin, Led3Pin, Led4Pin>>,
-    >,
+    button: ActorContext<'static, Button<'static, ExtiPin<PB2<Input<PullUp>>>, MyApp>>,
+    app: ActorContext<'static, MyApp>,
 }
 
 #[drogue::main(config = "embassy_stm32::hal::rcc::Config::hsi16()")]
@@ -143,10 +131,10 @@ async fn main(context: DeviceContext<MyDevice>) {
 
     let button = gpiob.pb2.into_pull_up_input();
 
-    let led1 = gpiob.pb5.into_push_pull_output();
-    let led2 = gpioa.pa5.into_push_pull_output();
-    let led3 = gpiob.pb6.into_push_pull_output();
-    let led4 = gpiob.pb7.into_push_pull_output();
+    let led1 = GpioLed::new(gpiob.pb5.into_push_pull_output());
+    let led2 = GpioLed::new(gpioa.pa5.into_push_pull_output());
+    let led3 = GpioLed::new(gpiob.pb6.into_push_pull_output());
+    let led4 = GpioLed::new(gpiob.pb7.into_push_pull_output());
 
     let pin = ExtiPin::new(button, irq, &mut syscfg);
 
@@ -181,14 +169,15 @@ async fn main(context: DeviceContext<MyDevice>) {
     log::info!("Configuring with config {:?}", config);
 
     context.configure(MyDevice {
-        app: ActorContext::new(App::new(config)),
+        app: ActorContext::new(App::new(AppInitConfig {
+            tx_led: led2,
+            green_led: led1,
+            init_led: led4,
+            user_led: led3,
+            lora: Some(config),
+        })),
         lora: ActorContext::new(LoraActor::new(lora)),
         button: ActorContext::new(Button::new(pin)),
-        led1: ActorContext::new(Led::new(led1)),
-        led2: ActorContext::new(Led::new(led2)),
-        led3: ActorContext::new(Led::new(led3)),
-        led4: ActorContext::new(Led::new(led4)),
-        ticker: ActorContext::new(Ticker::new(Duration::from_secs(60), Command::Send)),
     });
 
     /*
@@ -201,18 +190,7 @@ async fn main(context: DeviceContext<MyDevice>) {
 
     context.mount(|device| {
         let lora = device.lora.mount(());
-        let led1 = device.led1.mount(());
-        let led2 = device.led2.mount(());
-        let led3 = device.led3.mount(());
-        let led4 = device.led4.mount(());
-        let app = device.app.mount(AppConfig {
-            lora,
-            led1,
-            led2,
-            led3,
-            led4,
-        });
-        device.ticker.mount(app);
+        let app = device.app.mount(AppConfig { lora });
         device.button.mount(app);
     });
 }


### PR DESCRIPTION
I added an LED trait, instead of using the LED actor.

This also, partially, adds a ticker based approach for sending values to the cloud. However, due to the TTN fair use policy, it won't work that way. So I was reverting that back to "button press" approach.

If you don't like the mess in this PR, I can understand and would re-write history.