### PR TITLE
Add Error handling for notify and request calls

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -43,9 +43,10 @@ defmt = { version = "0.2", optional = true }
 embassy-std = {git = "https://github.com/drogue-iot/embassy.git", branch = "drogue", default-features = false } #, path = "../../../embassy/embassy-std" }
 futures = { version = "0.3", default-features = false, features = ["executor"] }
 arrayvec = { version = "0.7" }
+env_logger = "0.8"
 
 [features]
-default = [ "log" ]
+default = [ "log", "std" ]
 std = ["embassy/std", "embassy-std"]
 "chip+nrf52833" = ["embassy-nrf", "embassy-nrf/52833"]
 "chip+stm32l0x2" = ["embassy-stm32", "embassy-stm32/stm32l0x2" ]

--- a/device/src/actors/button.rs
+++ b/device/src/actors/button.rs
@@ -72,7 +72,7 @@ impl<'a, P: WaitForAnyEdge + InputPin + 'a, A: Actor + FromButtonEvent<A::Messag
                 if let Some(handler) = self.handler {
                     let mut message = A::from(event);
                     if let Some(m) = message.take() {
-                        handler.notify(m).await;
+                        let _ = handler.notify(m);
                     }
                 }
             }

--- a/device/src/actors/ticker.rs
+++ b/device/src/actors/ticker.rs
@@ -44,7 +44,9 @@ where
             loop {
                 Timer::after(self.interval).await;
                 if let Some(actor) = self.actor {
-                    actor.notify(self.message).await;
+                    // We continue even if we get an error, trying again
+                    // next tick.
+                    let _ = actor.notify(self.message);
                 }
             }
         }

--- a/device/src/actors/timer.rs
+++ b/device/src/actors/timer.rs
@@ -60,7 +60,7 @@ impl<'a, A: Actor + 'a> Actor for Timer<'a, A> {
                 }
                 TimerMessage::Schedule(dur, address, mut message) => {
                     time::Timer::after(dur).await;
-                    address.notify(message.take().unwrap()).await;
+                    let _ = address.notify(message.take().unwrap());
                 }
             }
         }

--- a/device/tests/integration_tests.rs
+++ b/device/tests/integration_tests.rs
@@ -39,7 +39,7 @@ mod tests {
             }
         }
 
-        #[derive(drogue::Device)]
+        #[derive(Device)]
         struct MyDevice {
             a: ActorContext<'static, MyActor>,
         }
@@ -54,7 +54,7 @@ mod tests {
 
             let a_addr = context.mount(|device| device.a.mount(()));
 
-            a_addr.request(Add(10)).await;
+            a_addr.request(Add(10)).unwrap().await;
         }
 
         std::thread::spawn(move || {

--- a/device/tests/timer_tests.rs
+++ b/device/tests/timer_tests.rs
@@ -5,7 +5,7 @@
 #![feature(generic_associated_types)]
 #![feature(type_alias_impl_trait)]
 
-#[cfg(feature = "std")]
+#[cfg(test)]
 mod tests {
     extern crate std;
     use drogue_device::{actors::timer::*, testutil::*, *};
@@ -36,7 +36,7 @@ mod tests {
                 handler_addr,
                 TestMessage(1),
             ))
-            .await;
+            .unwrap();
         notified.wait_signaled().await;
         let after = time::Instant::now();
         assert!(after.as_secs() >= before.as_secs() + 1);
@@ -59,6 +59,7 @@ mod tests {
         let before = time::Instant::now();
         timer
             .request(TimerMessage::Delay(time::Duration::from_secs(1)))
+            .unwrap()
             .await;
         let after = time::Instant::now();
         assert!(after.as_secs() >= before.as_secs() + 1);

--- a/examples/nrf52/microbit-esp8266/Cargo.toml
+++ b/examples/nrf52/microbit-esp8266/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 rtt-logger = "0.1"
 rtt-target = { version = "0.2.0", features = ["cortex-m"] }
 
-drogue-device = { path = "../../../device", features = ["chip+nrf52833", "wifi+esp8266"] }
+drogue-device = { path = "../../../device", features = ["chip+nrf52833", "wifi+esp8266"], default-features = false }
 cortex-m-rt = "0.6"
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 

--- a/examples/nrf52/microbit-uart/src/server.rs
+++ b/examples/nrf52/microbit-uart/src/server.rs
@@ -49,10 +49,10 @@ impl<'a, U: Write + Read + 'a> Actor for EchoServer<'a, U> {
         let statistics = self.statistics.unwrap();
         async move {
             for c in r"Hello, World!".chars() {
-                matrix.request(MatrixCommand::ApplyFrame(&c)).await;
+                matrix.request(MatrixCommand::ApplyFrame(&c)).unwrap().await;
                 Timer::after(Duration::from_millis(200)).await;
             }
-            matrix.notify(MatrixCommand::Clear).await;
+            matrix.notify(MatrixCommand::Clear).unwrap();
 
             let mut buf = [0; 128];
             let motd = "Welcome to the Drogue Echo Service\r\n".as_bytes();
@@ -65,9 +65,11 @@ impl<'a, U: Write + Read + 'a> Actor for EchoServer<'a, U> {
                 let _ = self.uart.write(&buf[..1]).await;
                 matrix
                     .request(MatrixCommand::ApplyFrame(&(buf[0] as char)))
+                    .unwrap()
                     .await;
                 statistics
                     .request(StatisticsCommand::IncrementCharacterCount)
+                    .unwrap()
                     .await;
             }
         }

--- a/examples/std/hello/src/main.rs
+++ b/examples/std/hello/src/main.rs
@@ -99,12 +99,12 @@ async fn main(context: DeviceContext<MyDevice>) {
 
     loop {
         time::Timer::after(time::Duration::from_secs(1)).await;
-        // Send that completes when message is enqueued
-        a_addr.notify(SayHello("World")).await;
+        // Send that completes immediately when message is enqueued
+        a_addr.notify(SayHello("World")).unwrap();
         // Send that waits until message is processed
-        b_addr.request(SayHello("You")).await;
+        b_addr.request(SayHello("You")).unwrap().await;
 
         // Actor uses a different counter
-        c_addr.notify(SayHello("There")).await;
+        c_addr.notify(SayHello("There")).unwrap();
     }
 }

--- a/examples/stm32l0xx/lora-discovery/Cargo.toml
+++ b/examples/stm32l0xx/lora-discovery/Cargo.toml
@@ -16,7 +16,7 @@ rtt-target = { version = "0.2.0", features = ["cortex-m"] }
 embedded-hal = { version = "0.2.4", features = ["unproven"] }
 panic-probe = { version = "0.2.0", features = ["print-rtt"] }
 
-drogue-device = { path = "../../../device", features = ["log", "chip+stm32l0x2", "lora+sx127x"] }
+drogue-device = { path = "../../../device", features = ["log", "chip+stm32l0x2", "lora+sx127x"], default-features = false }
 cortex-m-rt = "0.6"
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 heapless = "0.6"

--- a/examples/stm32l0xx/lora-discovery/src/app.rs
+++ b/examples/stm32l0xx/lora-discovery/src/app.rs
@@ -96,7 +96,11 @@ where
             let tx = tx.into_bytes();
 
             let mut rx = [0; 64];
-            let result = cfg.lora.request(LoraCommand::SendRecv(&tx, &mut rx)).await;
+            let result = cfg
+                .lora
+                .request(LoraCommand::SendRecv(&tx, &mut rx))
+                .unwrap()
+                .await;
 
             match result {
                 LoraResult::OkSent(rx_len) => {
@@ -174,8 +178,11 @@ where
             let lora_config = self.config.lora.take().unwrap();
             self.config.init_led.on().ok();
             if let Some(ref cfg) = self.cfg {
-                cfg.lora.request(LoraCommand::Configure(&lora_config)).await;
-                cfg.lora.request(LoraCommand::Join).await;
+                cfg.lora
+                    .request(LoraCommand::Configure(&lora_config))
+                    .unwrap()
+                    .await;
+                cfg.lora.request(LoraCommand::Join).unwrap().await;
             }
             self.config.init_led.off().ok();
         }


### PR DESCRIPTION
This changes the signature of notify() and request() to return a Result,
which will indicate if request can be made or not. For notify, the
operation may fail if the inbound channel is full. For request, the
operation may fail if the inbound channel is full or if there are no
available signals to capture the result.

Unit tests that verify Actor behavior is added.

Default features now include "std", which is usually the common case for
tests and simple examples.